### PR TITLE
build_order, quick_build_triggers, assorted fixes

### DIFF
--- a/BuildPlan.cs
+++ b/BuildPlan.cs
@@ -360,6 +360,8 @@ namespace LunarHelper
         {
             Program.Log("Checking Quick Build triggers...\n", ConsoleColor.Cyan);
 
+            bool any_triggered = false;
+
             var graph_copy = trigger_graph.Clone();
 
             List<Insertable> insertion_order = new List<Insertable>();
@@ -397,13 +399,15 @@ namespace LunarHelper
                     triggered_insertions = triggered_insertions.Concat(graph_copy.OutEdges(source).Select(e => e.Target)).ToHashSet();
                     triggered_insertions.Remove(source);
 
-                    if (triggered_insertions.Count() == 0)
-                        Program.Log("");
+                    any_triggered = true;
                 }
 
                 // remove our current vertex so that we can find a new source vertex in the next iteration
                 graph_copy.RemoveVertex(source);
             }
+
+            if (any_triggered)
+                Program.Log("");
 
             foreach (var non_trigger_change in detected_changes)
             {

--- a/BuildPlan.cs
+++ b/BuildPlan.cs
@@ -355,9 +355,11 @@ namespace LunarHelper
             return DetermineQuickBuildInsertionOrder(require_insertion, config.QuickBuildTriggerGraph);
         }
 
-        private static List<Insertable> DetermineQuickBuildInsertionOrder(List<Insertable> detected_changes, 
+        private static List<Insertable> DetermineQuickBuildInsertionOrder(List<Insertable> detected_changes,
             BidirectionalGraph<Insertable, Edge<Insertable>> trigger_graph)
         {
+            Program.Log("Checking Quick Build triggers...\n", ConsoleColor.Cyan);
+
             var graph_copy = trigger_graph.Clone();
 
             List<Insertable> insertion_order = new List<Insertable>();
@@ -386,9 +388,17 @@ namespace LunarHelper
                     // our vertex has no changes of its own but was triggered by some previous source
                     // vertex having had changes in its subtree, reinsert our vertex and also trigger
                     // reinsertion of our neighboring vertices
+                    var as_string = source.type == InsertableType.SinglePatch ? $"Patch '{source.normalized_relative_path}'" :
+                        source.type.ToString();
+                    Program.Lognl(as_string, ConsoleColor.Cyan);
+                    Program.Log($" must be (re)inserted due to Quick Build triggers specification", ConsoleColor.Yellow);
+
                     insertion_order.Add(source);
                     triggered_insertions = triggered_insertions.Concat(graph_copy.OutEdges(source).Select(e => e.Target)).ToHashSet();
                     triggered_insertions.Remove(source);
+
+                    if (triggered_insertions.Count() == 0)
+                        Program.Log("");
                 }
 
                 // remove our current vertex so that we can find a new source vertex in the next iteration
@@ -402,6 +412,7 @@ namespace LunarHelper
 
             return insertion_order;
         }
+
 
         private static List<Insertable> GatherInsertables(Insertable insertable, List<Insertable> insertables)
         {

--- a/BuildPlan.cs
+++ b/BuildPlan.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Text;
 using System.IO;
@@ -88,7 +88,7 @@ namespace LunarHelper
                 throw new MustRebuildException();
             }
 
-            if (report.build_order_hash != Report.HashList(config.BuildOrder))
+            if (report.build_order_hash != Report.HashBuildOrder(config.BuildOrder))
             {
                 Program.Log("'build_order' has changed, rebuilding ROM...\n", ConsoleColor.Yellow);
                 throw new MustRebuildException();

--- a/BuildPlan.cs
+++ b/BuildPlan.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using Newtonsoft.Json;
 using QuickGraph;
+using System.Reflection;
 
 namespace LunarHelper
 {
@@ -77,15 +78,25 @@ namespace LunarHelper
             }
             catch(Exception)
             {
-                Program.Log("Previous build report was found but corrupted, rebuilding ROM...", ConsoleColor.Yellow);
-                Console.WriteLine();
+                Program.Log("Previous build report was found but corrupted, rebuilding ROM...\n", ConsoleColor.Yellow);
                 throw new MustRebuildException();
             }
 
             if (report.report_format_version != Report.REPORT_FORMAT_VERSION)
             {
-                Program.Log("Previous build report found but used old format, rebuilding ROM...", ConsoleColor.Yellow);
-                Console.WriteLine();
+                Program.Log("Previous build report found but used old format, rebuilding ROM...\n", ConsoleColor.Yellow);
+                throw new MustRebuildException();
+            }
+
+            if (report.build_order_hash != Report.HashList(config.BuildOrder))
+            {
+                Program.Log("'build_order' has changed, rebuilding ROM...\n", ConsoleColor.Yellow);
+                throw new MustRebuildException();
+            }
+
+            if (report.lunar_helper_version != Assembly.GetExecutingAssembly().GetName().Version.ToString())
+            {
+                Program.Log($"Previous ROM was built with Lunar Helper {report.lunar_helper_version}, rebuilding ROM...\n", ConsoleColor.Yellow);
                 throw new MustRebuildException();
             }
 

--- a/Config.cs
+++ b/Config.cs
@@ -352,8 +352,17 @@ namespace LunarHelper
 
             foreach ((var trigger, var insertable) in config.QuickBuildTriggers)
             {
-                if (!config.BuildOrder.Contains(trigger) || !config.BuildOrder.Contains(insertable))
-                    throw new Exception("Resources used in 'quick_build_triggers' must also be present in 'build_order'");
+                if (!config.BuildOrder.Contains(trigger))
+                {
+                    if (trigger.type != InsertableType.SinglePatch || !config.BuildOrder.Any(i => i.type == InsertableType.Patches))
+                        throw new Exception("Resources used in 'quick_build_triggers' must also be present in 'build_order'");
+                }
+
+                if (!config.BuildOrder.Contains(insertable))
+                {
+                    if (insertable.type != InsertableType.SinglePatch || !config.BuildOrder.Any(i => i.type == InsertableType.Patches))
+                        throw new Exception("Resources used in 'quick_build_triggers' must also be present in 'build_order'");
+                }
 
                 trigger_graph.AddVertex(trigger);
                 trigger_graph.AddVertex(insertable);

--- a/Config.cs
+++ b/Config.cs
@@ -1,4 +1,4 @@
-using QuickGraph;
+﻿using QuickGraph;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -333,6 +333,9 @@ namespace LunarHelper
 
             foreach ((var trigger, var insertable) in config.QuickBuildTriggers)
             {
+                if (!config.BuildOrder.Contains(trigger) || !config.BuildOrder.Contains(insertable))
+                    throw new Exception("Resources used in 'quick_build_triggers' must also be present in 'build_order'");
+
                 trigger_graph.AddVertex(trigger);
                 trigger_graph.AddVertex(insertable);
                 trigger_graph.AddEdge(new Edge<Insertable>(trigger, insertable));

--- a/Config.cs
+++ b/Config.cs
@@ -1,10 +1,15 @@
-﻿using System;
+﻿using QuickGraph;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.IO;
 using System.Linq;
 using System.Text;
+
+using QuickGraph.Algorithms;
+using QuickGraph.Algorithms.Search;
+using QuickGraph.Algorithms.ConnectedComponents;
 
 namespace LunarHelper
 {
@@ -57,6 +62,10 @@ namespace LunarHelper
         public bool ReloadEmulatorAfterBuild;
         public bool SuppressArbitraryDepsWarning;
 
+        public List<Insertable> BuildOrder = null;
+        List<(Insertable, Insertable)> QuickBuildTriggers = new List<(Insertable, Insertable)>();
+        public BidirectionalGraph<Insertable, Edge<Insertable>> QuickBuildTriggerGraph = null;
+
         #region load
 
         static public Config Load(out string error, Config config = null, string search_path_prefix = "")
@@ -87,7 +96,7 @@ namespace LunarHelper
             Dictionary<string, string> vars = new Dictionary<string, string>();
             Dictionary<string, List<string>> lists = new Dictionary<string, List<string>>();
             List<Insertable> build_order = new List<Insertable>();
-            List<(Insertable, List <Insertable>)> quick_build_triggers = new List<(Insertable, List<Insertable>)>();
+            List<(Insertable, Insertable)> quick_build_triggers = new List<(Insertable, Insertable)>();
 
             foreach (var d in data)
                 Parse(d, vars, lists, build_order, quick_build_triggers);
@@ -141,16 +150,21 @@ namespace LunarHelper
                 config.SuppressArbitraryDepsWarning = suppress_arbitrary_deps_warning != null ? (new[] { "yes", "true" }).AsSpan().Contains(suppress_arbitrary_deps_warning.Trim()) : false;
             }
 
-            if (build_order.Count() == 0)
+            if (build_order.Count() != 0)
             {
-                throw new Exception("'build_order' list must be specified");
+                config.BuildOrder = build_order;
+            }
+
+            if (quick_build_triggers.Count() != 0)
+            {
+                config.QuickBuildTriggers = quick_build_triggers;
             }
 
             return config;
         }
 
         static private void Parse(string data, Dictionary<string, string> vars, Dictionary<string, 
-            List<string>> lists, List<Insertable> build_order, List<(Insertable, List<Insertable>)> quick_build_triggers)
+            List<string>> lists, List<Insertable> build_order, List<(Insertable, Insertable)> quick_build_triggers)
         {
             var lines = data.Split('\n');
             for (int i = 0; i < lines.Length; i++)
@@ -178,14 +192,15 @@ namespace LunarHelper
                 }
                 else if (peek != null && peek.Trim() == "[")
                 {
-                    if (new[] {"quick_build_triggers", "build_order"}.Contains(str))
+                    var trimmed = str.Trim();
+                    if (new[] {"quick_build_triggers", "build_order"}.Contains(trimmed))
                     {
-                        ParseDependencyList(str, build_order, quick_build_triggers, lines, i + 2);
+                        ParseDependencyList(trimmed, build_order, quick_build_triggers, lines, i + 2);
                         continue;
                     }
                     // list
                     var list = new List<string>();
-                    lists.Add(str.Trim(), list);
+                    lists.Add(trimmed, list);
                     i += 2;
 
                     while (true)
@@ -197,7 +212,8 @@ namespace LunarHelper
                         if (str.Trim() == "]")
                             break;
                         else
-                            list.Add(str.Trim().Replace("\\", "/"));
+                            list.Add(str.Trim().Replace('/', '\\').TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+                                .ToLowerInvariant());
 
                         i++;
                     }
@@ -206,7 +222,7 @@ namespace LunarHelper
         }
 
         static private void ParseDependencyList(string list_name, List<Insertable> build_order, 
-            List<(Insertable, List<Insertable>)> quick_build_triggers, string[] lines, int line_idx)
+            List<(Insertable, Insertable)> quick_build_triggers, string[] lines, int line_idx)
         {
             while (true)
             {
@@ -220,12 +236,12 @@ namespace LunarHelper
                 {
                     if (list_name == "build_order")
                     {
-                        build_order.Append(ParseInsertable(str));
+                        build_order.Add(ParseInsertable(str));
                     }
                     else
                     {
-                        (var trigger, var insertables) = ParseQuickBuildTriggers(str);
-                        quick_build_triggers.Add((trigger, insertables));
+                        (var trigger, var insertable) = ParseQuickBuildTrigger(str);
+                        quick_build_triggers.Add((trigger, insertable));
                     }
                 }
 
@@ -233,33 +249,31 @@ namespace LunarHelper
             }
         }
 
-        static private (Insertable, List<Insertable>) ParseQuickBuildTriggers(string line)
+        static private (Insertable, Insertable) ParseQuickBuildTrigger(string line)
         {
             string trimmed_line = line.Trim();
 
-            int arrow_idx = trimmed_line.IndexOf(" -> ");
+            var split = trimmed_line.Split(" -> ");
 
-            if (arrow_idx == -1)
-            {
-                throw new Exception($"Malformed quick build trigger, missing '->': '{line}'");
-            }
+            if (split.Length != 2)
+                throw new Exception($"Malformed Quick Build trigger: '{line}'");
 
-            Insertable trigger = ParseInsertable(trimmed_line.Substring(0, arrow_idx).Trim());
-
-            var to_insert = trimmed_line.Substring(arrow_idx + 4).Split(", ")
-                .Select(i => ParseInsertable(i.Trim()));
-
-            return (trigger, to_insert.ToList());
+            return (ParseInsertable(split[0], true), ParseInsertable(split[1], true));
         }
 
-        static private Insertable ParseInsertable(string insertable_string)
+        static private Insertable ParseInsertable(string insertable_string, bool is_quickbuild = false)
         {
             string trimmed = insertable_string.Trim();
 
             InsertableType insertable_type;
             bool success = Enum.TryParse(trimmed, true, out insertable_type);
 
-            if (success && insertable_type != InsertableType.SinglePatch)
+            if (is_quickbuild && insertable_type == InsertableType.Patches)
+            {
+                throw new Exception("'Patches' cannot be used in Quick Build triggers, please specify individual patches instead");
+            }
+
+            if (success && insertable_type != InsertableType.SinglePatch && insertable_type != InsertableType.SingleLevel)
             {
                 return new Insertable(insertable_type);
             }
@@ -267,6 +281,184 @@ namespace LunarHelper
             {
                 return new Insertable(InsertableType.SinglePatch, trimmed);
             }
+        }
+
+        static private Dictionary<InsertableType, Action<Config>> verifications = new Dictionary<InsertableType, Action<Config>>()
+        {
+            { InsertableType.Pixi, VerifyPixi },
+            { InsertableType.AddMusicK, VerifyAmk },
+            { InsertableType.Gps, VerifyGps },
+            { InsertableType.UberAsm, VerifyUberAsm },
+            { InsertableType.Graphics, NoVerify },
+            { InsertableType.ExGraphics, NoVerify },
+            { InsertableType.Map16, VerifyMap16 },
+            { InsertableType.SharedPalettes, VerifySharedPalettes },
+            { InsertableType.GlobalData, VerifyGlobalData },
+            { InsertableType.TitleMoves, VerifyTitleMoves },
+            { InsertableType.Levels, VerifyLevels },
+            { InsertableType.Patches, VerifyPatches }
+        };
+
+        private static void VerifyInsertable(Config config, Insertable insertable)
+        {
+            var type = insertable.type;
+
+            if (type == InsertableType.SinglePatch)
+                VerifyPatch(config, insertable.normalized_relative_path);
+            else
+                verifications[type](config);
+        }
+
+        public static void VerifyConfig(Config config)
+        {
+            if (config.BuildOrder == null)
+            {
+                throw new Exception("'build_order' list must be specified");
+            }
+            if (config.QuickBuildTriggers == null)
+            {
+                throw new Exception("'quick_build_triggers' list must be specified");
+            }
+
+            foreach (var item in config.BuildOrder)
+                VerifyInsertable(config, item);
+
+            BidirectionalGraph<Insertable, Edge<Insertable>> trigger_graph = new BidirectionalGraph<Insertable, Edge<Insertable>>();
+
+            foreach ((var trigger, var insertable) in config.QuickBuildTriggers)
+            {
+                trigger_graph.AddVertex(trigger);
+                trigger_graph.AddVertex(insertable);
+                trigger_graph.AddEdge(new Edge<Insertable>(trigger, insertable));
+            }
+
+            if (trigger_graph.Edges.Any(e => e.Source.Equals(e.Target)))
+                throw new Exception("Cyclic triggers detected in Quick Build trigger list");
+
+            var ssc = new StronglyConnectedComponentsAlgorithm<Insertable, Edge<Insertable>>(trigger_graph);
+
+            ssc.Compute();
+
+            bool cycles_present = ssc.ComponentCount != trigger_graph.VertexCount;  // if all strongly connected components are
+                                                                                    // single vertices, our graph is acyclic
+
+            if (cycles_present)
+                throw new Exception("Cyclic triggers detected in Quick Build trigger list");
+
+            config.QuickBuildTriggerGraph = trigger_graph;
+
+            foreach ((var trigger, var insertable) in config.QuickBuildTriggers)
+            {
+                VerifyInsertable(config, trigger);
+                VerifyInsertable(config, insertable);
+            }
+        }
+
+        private static void VerifyPatch(Config config, string patch_path)
+        {
+            if (string.IsNullOrEmpty(config.AsarPath))
+                throw new Exception($"No path to asar specified, but patch '{patch_path}' must be inserted");
+
+            if (!File.Exists(config.AsarPath))
+                throw new Exception($"Asar not found at path '{config.AsarPath}'");
+
+            if (!File.Exists(patch_path))
+                throw new Exception($"Patch '{patch_path}' not found");
+
+            if (!config.Patches.Contains(patch_path))
+                throw new Exception($"Patch '{patch_path}' specified in build order but not found in patch list");
+        }
+
+        private static void VerifyPatches(Config config)
+        {
+            foreach (var patch in config.Patches)
+            {
+                VerifyPatch(config, patch);
+            }
+        }
+
+        private static void VerifyUnspecifiedOrExists(Config config, InsertableType insertable_type, 
+            string corresponding_variable, string tool_name, string tool_path)
+        {
+            if (string.IsNullOrWhiteSpace(tool_path))
+                VerifyNotInBuildOrQuickTriggers(config, insertable_type, corresponding_variable);
+
+            if (!File.Exists(tool_path))
+                throw new Exception($"{tool_name} not found at path '{tool_path}'");
+        }
+
+        private static void VerifyNotInBuildOrQuickTriggers(Config config, InsertableType type, string corresponding_variable)
+        {
+            if (config.BuildOrder.Any(i => i.type == type))
+            {
+                throw new Exception($"{corresponding_variable} not specified, but {type} found in build_order list");
+            }
+
+            if (config.QuickBuildTriggerGraph.Vertices.Any(i => i.type == type))
+            {
+                throw new Exception($"{corresponding_variable} not specified, but {type} found in quick_build_triggers list");
+            }
+        }
+
+        private static void VerifyPixi(Config config)
+        {
+            VerifyUnspecifiedOrExists(config, InsertableType.Pixi, "pixi_path", "PIXI", config.PixiPath);
+        }
+
+        private static void VerifyAmk(Config config)
+        {
+            VerifyUnspecifiedOrExists(config, InsertableType.AddMusicK, "addmusick_path", "AddMusicK", config.AddMusicKPath);
+        }
+
+        private static void VerifyGps(Config config)
+        {
+            VerifyUnspecifiedOrExists(config, InsertableType.Gps, "gps_path", "GPS", config.GPSPath);
+        }
+
+        private static void VerifyUberAsm(Config config)
+        {
+            VerifyUnspecifiedOrExists(config, InsertableType.UberAsm, "uberasm_path", "UberASM Tool", config.UberASMPath);
+        }
+
+        private static void NoVerify(Config config)
+        {
+            // nothing to verify
+        }
+
+        private static void VerifyMap16(Config config)
+        {
+            if (string.IsNullOrWhiteSpace(config.Map16Path))
+                VerifyNotInBuildOrQuickTriggers(config, InsertableType.Map16, "map16");
+
+            if (string.IsNullOrWhiteSpace(config.HumanReadableMap16CLI))
+                return;
+
+            if (!File.Exists(config.HumanReadableMap16CLI))
+                throw new Exception($"Human Readable Map16 CLI not found at path '{config.HumanReadableMap16CLI}'");
+        }
+
+        private static void VerifyTitleMoves(Config config)
+        {
+            if (string.IsNullOrWhiteSpace(config.TitleMovesPath))
+                VerifyNotInBuildOrQuickTriggers(config, InsertableType.TitleMoves, "title_moves");
+        }
+
+        private static void VerifySharedPalettes(Config config)
+        {
+            if (string.IsNullOrWhiteSpace(config.SharedPalettePath))
+                VerifyNotInBuildOrQuickTriggers(config, InsertableType.SharedPalettes, "shared_palette");
+        }
+
+        private static void VerifyLevels(Config config)
+        {
+            if (string.IsNullOrWhiteSpace(config.LevelsPath))
+                VerifyNotInBuildOrQuickTriggers(config, InsertableType.Levels, "levels");
+        }
+
+        private static void VerifyGlobalData(Config config)
+        {
+            if (string.IsNullOrWhiteSpace(config.GlobalDataPath))
+                VerifyNotInBuildOrQuickTriggers(config, InsertableType.GlobalData, "global_data");
         }
 
         #endregion

--- a/Config.cs
+++ b/Config.cs
@@ -1,4 +1,4 @@
-﻿using QuickGraph;
+using QuickGraph;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -318,6 +318,12 @@ namespace LunarHelper
             if (config.QuickBuildTriggers == null)
             {
                 throw new Exception("'quick_build_triggers' list must be specified");
+            }
+
+            if (config.Patches.Count() != 0 && !(config.BuildOrder.Any(i => i.type == InsertableType.Patches) ||
+                config.Patches.All(p => config.BuildOrder.Contains(new Insertable(InsertableType.SinglePatch, p)))))
+            {
+                throw new Exception("Not all patches listed in 'patches' appear in 'build_order'");
             }
 
             foreach (var item in config.BuildOrder)

--- a/Config.cs
+++ b/Config.cs
@@ -366,7 +366,7 @@ namespace LunarHelper
                 throw new Exception($"Patch '{patch_path}' not found");
 
             if (!config.Patches.Contains(patch_path))
-                throw new Exception($"Patch '{patch_path}' specified in build order but not found in patch list");
+                throw new Exception($"Patch '{patch_path}' not found");
         }
 
         private static void VerifyPatches(Config config)

--- a/Config.cs
+++ b/Config.cs
@@ -167,6 +167,29 @@ namespace LunarHelper
             List<string>> lists, List<Insertable> build_order, List<(Insertable, Insertable)> quick_build_triggers)
         {
             var lines = data.Split('\n');
+
+            List<string> cleaned_lines = new List<string>();
+
+            foreach (var line in lines)
+            {
+                var trimmed = line.Trim();
+
+                if (trimmed.StartsWith("--"))
+                    continue;  // line is just comment, skip it
+
+                if (trimmed == "")
+                    continue;  // blank line, skip it
+
+                int comment_start = trimmed.IndexOf("--");
+
+                if (comment_start != -1)
+                    trimmed = trimmed.Substring(0, comment_start);
+
+                cleaned_lines.Add(trimmed);
+            }
+
+            lines = cleaned_lines.ToArray();
+
             for (int i = 0; i < lines.Length; i++)
             {
                 string str = lines[i];
@@ -174,11 +197,7 @@ namespace LunarHelper
                 if (i < lines.Length - 1)
                     peek = lines[i + 1];
 
-                if (str.StartsWith("--"))
-                {
-                    // comment
-                }
-                else if (str.Contains('='))
+                if (str.Contains('='))
                 {
                     // var
                     var sp = str.Split('=', 2);

--- a/DependencyGraph.cs
+++ b/DependencyGraph.cs
@@ -27,25 +27,25 @@ namespace LunarHelper
             dependency_graph = new BidirectionalGraph<Vertex, STaggedEdge<Vertex, string>>();
             resolver = new DependencyResolver(this, config);
 
-            if (resolver.CanResolveAmk())
+            if (resolver.CanResolveAmk() && config.BuildOrder.Any(i => i.type == InsertableType.AddMusicK))
             {
                 amk_root = CreateToolRootVertex(ToolRootVertex.Tool.Amk);
                 resolver.ResolveToolRootDependencies(amk_root);
             }
 
-            if (resolver.CanResolvePixi())
+            if (resolver.CanResolvePixi() && config.BuildOrder.Any(i => i.type == InsertableType.Pixi))
             {
                 pixi_root = CreateToolRootVertex(ToolRootVertex.Tool.Pixi);
                 resolver.ResolveToolRootDependencies(pixi_root);
             }
 
-            if (resolver.CanResolveGps())
+            if (resolver.CanResolveGps() && config.BuildOrder.Any(i => i.type == InsertableType.Gps))
             {
                 gps_root = CreateToolRootVertex(ToolRootVertex.Tool.Gps);
                 resolver.ResolveToolRootDependencies(gps_root);
             }
 
-            if (resolver.CanResolveUberAsm())
+            if (resolver.CanResolveUberAsm() && config.BuildOrder.Any(i => i.type == InsertableType.UberAsm))
             {
                 uberasm_root = CreateToolRootVertex(ToolRootVertex.Tool.UberAsm);
                 resolver.ResolveToolRootDependencies(uberasm_root);
@@ -69,7 +69,7 @@ namespace LunarHelper
         {
             foreach (string user_specified_patch_path in config.Patches)
             {
-                Vertex patch_root = null;
+                Vertex patch_root;
 
                 try
                 {

--- a/Exporter.cs
+++ b/Exporter.cs
@@ -1,0 +1,209 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace LunarHelper
+{
+    using static Program;
+
+    internal class Exporter
+    {
+        static public bool ExportAll(Config config)
+        {
+            if (!File.Exists(config.OutputPath))
+            {
+                Log("Output ROM does not exist! Build first!", ConsoleColor.Red);
+                return false;
+            }
+
+            // save global data
+            Log("Saving Global Data BPS...", ConsoleColor.Cyan);
+            if (string.IsNullOrWhiteSpace(config.GlobalDataPath))
+                Log("No path for GlobalData BPS provided!", ConsoleColor.Red);
+            else if (string.IsNullOrWhiteSpace(config.CleanPath))
+                Log("No path for Clean ROM provided!", ConsoleColor.Red);
+            else if (!File.Exists(config.CleanPath))
+                Log("Clean ROM does not exist!", ConsoleColor.Red);
+            else if (string.IsNullOrWhiteSpace(config.FlipsPath))
+                Log("No path to Flips provided!", ConsoleColor.Red);
+            else if (!File.Exists(config.FlipsPath))
+                Log("Flips not found at the provided path!", ConsoleColor.Red);
+            else
+            {
+                if (File.Exists(config.GlobalDataPath))
+                    File.Delete(config.GlobalDataPath);
+
+                var fullCleanPath = Path.GetFullPath(config.CleanPath);
+                var fullOutputPath = Path.GetFullPath(config.OutputPath);
+                var fullPackagePath = Path.GetFullPath(config.GlobalDataPath);
+                if (CreatePatch(config, fullCleanPath, fullOutputPath, fullPackagePath))
+                    Log("Global Data Patch Success!", ConsoleColor.Green);
+                else
+                {
+                    Log("Global Data Patch Failure!", ConsoleColor.Red);
+                    return false;
+                }
+            }
+
+            // export map16
+            Log("Exporting Map16...", ConsoleColor.Cyan);
+            if (string.IsNullOrWhiteSpace(config.Map16Path))
+                Log("No path for Map16 provided!", ConsoleColor.Red);
+            else if (string.IsNullOrWhiteSpace(config.LunarMagicPath))
+                Log("No Lunar Magic Path provided!", ConsoleColor.Red);
+            else if (!File.Exists(config.LunarMagicPath))
+                Log("Could not find Lunar Magic at the provided path!", ConsoleColor.Red);
+            else
+            {
+                Console.ForegroundColor = ConsoleColor.Yellow;
+                ProcessStartInfo psi = new ProcessStartInfo(config.LunarMagicPath,
+                            $"-ExportAllMap16 \"{config.OutputPath}\" \"{config.Map16Path}\"");
+                var p = Process.Start(psi);
+                p.WaitForExit();
+
+                if (p.ExitCode == 0)
+                    Log("Map16 Export Success!", ConsoleColor.Green);
+                else
+                {
+                    Log("Map16 Export Failure!", ConsoleColor.Red);
+                    return false;
+                }
+
+                if (string.IsNullOrWhiteSpace(config.HumanReadableMap16CLI))
+                    Log("No path to human-readable-map16-cli.exe provided, using binary map16 format", ConsoleColor.Red);
+                else
+                {
+                    string humanReadableDirectory;
+                    if (!string.IsNullOrWhiteSpace(config.HumanReadableMap16Directory))
+                        humanReadableDirectory = config.HumanReadableMap16Directory;
+                    else
+                        humanReadableDirectory = Path.Combine(Path.GetDirectoryName(config.Map16Path), Path.GetFileNameWithoutExtension(config.Map16Path));
+
+                    Console.ForegroundColor = ConsoleColor.Yellow;
+                    ProcessStartInfo process = new ProcessStartInfo(config.HumanReadableMap16CLI,
+                                $"--from-map16 \"{config.Map16Path}\" \"{humanReadableDirectory}\"");
+                    var proc = Process.Start(process);
+                    proc.WaitForExit();
+
+                    if (proc.ExitCode == 0)
+                        Log("Human Readable Map16 Conversion Success!", ConsoleColor.Green);
+                    else
+                    {
+                        Log("Human Readable Map16 Conversion Failure!", ConsoleColor.Red);
+                        return false;
+                    }
+                }
+            }
+
+            // export shared palette
+            Log("Exporting Shared Palette...", ConsoleColor.Cyan);
+            if (string.IsNullOrWhiteSpace(config.SharedPalettePath))
+                Log("No path for Shared Palette provided!", ConsoleColor.Red);
+            else if (string.IsNullOrWhiteSpace(config.LunarMagicPath))
+                Log("No Lunar Magic Path provided!", ConsoleColor.Red);
+            else if (!File.Exists(config.LunarMagicPath))
+                Log("Could not find Lunar Magic at the provided path!", ConsoleColor.Red);
+            else
+            {
+                Console.ForegroundColor = ConsoleColor.Yellow;
+                ProcessStartInfo psi = new ProcessStartInfo(config.LunarMagicPath,
+                            $"-ExportSharedPalette \"{config.OutputPath}\" \"{config.SharedPalettePath}\"");
+                var p = Process.Start(psi);
+                p.WaitForExit();
+
+                if (p.ExitCode == 0)
+                    Log("Shared Palette Export Success!", ConsoleColor.Green);
+                else
+                {
+                    Log("Shared Palette Export Failure!", ConsoleColor.Red);
+                    return false;
+                }
+            }
+
+            // export title moves
+            Log("Exporting Title Moves...", ConsoleColor.Cyan);
+            if (string.IsNullOrWhiteSpace(config.TitleMovesPath))
+                Log("No path for Title Moves provided!", ConsoleColor.Red);
+            else if (string.IsNullOrWhiteSpace(config.LunarMagicPath))
+                Log("No Lunar Magic Path provided!", ConsoleColor.Red);
+            else if (!File.Exists(config.LunarMagicPath))
+                Log("Could not find Lunar Magic at the provided path!", ConsoleColor.Red);
+            else
+            {
+                Console.ForegroundColor = ConsoleColor.Yellow;
+                ProcessStartInfo psi = new ProcessStartInfo(config.LunarMagicPath,
+                            $"-ExportTitleMoves \"{config.OutputPath}\" \"{config.TitleMovesPath}\"");
+                var p = Process.Start(psi);
+                p.WaitForExit();
+
+                if (p.ExitCode == 0)
+                    Log("Title Moves Export Success!", ConsoleColor.Green);
+                else
+                {
+                    Log("Title Moves Export Failure!", ConsoleColor.Red);
+                    return false;
+                }
+            }
+
+            // save levels
+            if (!ExportLevels(config))
+                return false;
+
+            Console.WriteLine();
+            return true;
+        }
+
+        static public bool CreatePatch(Config config, string cleanROM, string hackROM, string outputBPS)
+        {
+            Log($"Creating Patch {outputBPS}\n\twith {hackROM}\n\tover {cleanROM}", ConsoleColor.Yellow);
+
+            Console.ForegroundColor = ConsoleColor.Yellow;
+            var psi = new ProcessStartInfo(config.FlipsPath,
+                    $"--create --bps-delta \"{cleanROM}\" \"{hackROM}\" \"{outputBPS}\"");
+            var p = Process.Start(psi);
+            p.WaitForExit();
+
+            if (p.ExitCode == 0)
+                return true;
+            else
+                return false;
+        }
+
+        static private bool ExportLevels(Config config)
+        {
+            Log("Exporting All Levels...", ConsoleColor.Cyan);
+            if (string.IsNullOrWhiteSpace(config.LevelsPath))
+                Log("No path for Levels provided!", ConsoleColor.Red);
+            else if (string.IsNullOrWhiteSpace(config.LunarMagicPath))
+                Log("No Lunar Magic Path provided!", ConsoleColor.Red);
+            else if (!File.Exists(config.LunarMagicPath))
+                Log("Could not find Lunar Magic at the provided path!", ConsoleColor.Red);
+            else if (!File.Exists(config.OutputPath))
+                Log("Output ROM does not exist! Build first!", ConsoleColor.Red);
+            else
+            {
+                Console.ForegroundColor = ConsoleColor.Yellow;
+                ProcessStartInfo psi = new ProcessStartInfo(config.LunarMagicPath,
+                            $"-ExportMultLevels \"{config.OutputPath}\" \"{config.LevelsPath}{Path.DirectorySeparatorChar}level\"");
+                var p = Process.Start(psi);
+                p.WaitForExit();
+
+                if (p.ExitCode == 0)
+                {
+                    Log("Levels Export Success!", ConsoleColor.Green);
+                    return true;
+                }
+                else
+                {
+                    Log("Levels Export Failure!", ConsoleColor.Red);
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/Importer.cs
+++ b/Importer.cs
@@ -1,0 +1,474 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace LunarHelper
+{
+    using static Program;
+
+    internal class Importer
+    {
+        static private string UBERASM_SUCCESS_STRING = "Codes inserted successfully.";
+
+        static public bool ApplyPatch(Config config, string cleanROM, string outROM, string patchBPS)
+        {
+            Log($"Patching {cleanROM}\n\tto {outROM}\n\twith {patchBPS}", ConsoleColor.Yellow);
+
+            Console.ForegroundColor = ConsoleColor.Yellow;
+            var psi = new ProcessStartInfo(config.FlipsPath,
+                    $"--apply \"{patchBPS}\" \"{cleanROM}\" \"{outROM}\"");
+            var p = Process.Start(psi);
+            p.WaitForExit();
+
+            if (p.ExitCode == 0)
+                return true;
+            else
+                return false;
+        }
+
+        static public bool ImportGlobalData(Config config)
+        {
+            Log("Global Data", ConsoleColor.Cyan);
+
+            ProcessStartInfo psi;
+            Process p;
+            string globalDataROMPath = Path.Combine(
+                Path.GetFullPath(Path.GetDirectoryName(config.GlobalDataPath)),
+                Path.GetFileNameWithoutExtension(config.GlobalDataPath) + ".smc");
+
+            //Apply patch to clean ROM
+            {
+                var fullPatchPath = Path.GetFullPath(config.GlobalDataPath);
+                var fullCleanPath = Path.GetFullPath(config.CleanPath);
+
+                Console.ForegroundColor = ConsoleColor.Yellow;
+                psi = new ProcessStartInfo(config.FlipsPath,
+                        $"--apply \"{fullPatchPath}\" \"{fullCleanPath}\" \"{globalDataROMPath}\"");
+                p = Process.Start(psi);
+                p.WaitForExit();
+
+                if (p.ExitCode == 0)
+                    Log("Global Data Patch Success!", ConsoleColor.Green);
+                else
+                {
+                    Log("Global Data Patch Failure!", ConsoleColor.Red);
+                    return false;
+                }
+            }
+
+            //Overworld
+            {
+                Console.ForegroundColor = ConsoleColor.Yellow;
+                psi = new ProcessStartInfo(config.LunarMagicPath,
+                            $"-TransferOverworld \"{config.TempPath}\" \"{globalDataROMPath}\"");
+                p = Process.Start(psi);
+                p.WaitForExit();
+
+                if (p.ExitCode == 0)
+                    Log("Overworld Import Success!", ConsoleColor.Green);
+                else
+                {
+                    Log("Overworld Import Failure!", ConsoleColor.Red);
+                    return false;
+                }
+            }
+
+            //Global EX Animations
+            {
+                Console.ForegroundColor = ConsoleColor.Yellow;
+                psi = new ProcessStartInfo(config.LunarMagicPath,
+                            $"-TransferLevelGlobalExAnim \"{config.TempPath}\" \"{globalDataROMPath}\"");
+                p = Process.Start(psi);
+                p.WaitForExit();
+
+                if (p.ExitCode == 0)
+                    Log("Global EX Animation Import Success!", ConsoleColor.Green);
+                else
+                {
+                    Log("Global EX Animation Import Failure!", ConsoleColor.Red);
+                    return false;
+                }
+            }
+
+            //Title Screen
+            {
+                Console.ForegroundColor = ConsoleColor.Yellow;
+                psi = new ProcessStartInfo(config.LunarMagicPath,
+                            $"-TransferTitleScreen \"{config.TempPath}\" \"{globalDataROMPath}\"");
+                p = Process.Start(psi);
+                p.WaitForExit();
+
+                if (p.ExitCode == 0)
+                    Log("Title Screen Import Success!", ConsoleColor.Green);
+                else
+                {
+                    Log("Title Screen Import Failure!", ConsoleColor.Red);
+                    return false;
+                }
+            }
+
+            //Credits
+            {
+                Console.ForegroundColor = ConsoleColor.Yellow;
+                psi = new ProcessStartInfo(config.LunarMagicPath,
+                            $"-TransferCredits \"{config.TempPath}\" \"{globalDataROMPath}\"");
+                p = Process.Start(psi);
+                p.WaitForExit();
+
+                if (p.ExitCode == 0)
+                    Log("Credits Import Success!", ConsoleColor.Green);
+                else
+                {
+                    Log("Credits Import Failure!", ConsoleColor.Red);
+                    return false;
+                }
+            }
+
+            if (File.Exists(globalDataROMPath))
+                File.Delete(globalDataROMPath);
+
+            Log("All Global Data Imported!", ConsoleColor.Green);
+            Console.WriteLine();
+
+            return true;
+        }
+
+        static public bool ImportSharedPalettes(Config config)
+        {
+            Log("Shared Palette", ConsoleColor.Cyan);
+
+            Console.ForegroundColor = ConsoleColor.Yellow;
+            ProcessStartInfo psi = new ProcessStartInfo(config.LunarMagicPath,
+                        $"-ImportSharedPalette \"{config.TempPath}\" \"{config.SharedPalettePath}\"");
+            var p = Process.Start(psi);
+            p.WaitForExit();
+
+            if (p.ExitCode == 0)
+                Log("Shared Palette Import Success!", ConsoleColor.Green);
+            else
+            {
+                Log("Shared Palette Import Failure!", ConsoleColor.Red);
+                return false;
+            }
+
+            Console.WriteLine();
+
+            return true;
+        }
+
+        static public bool ImportTitleMoves(Config config)
+        {
+            Log("Title Moves", ConsoleColor.Cyan);
+
+            Console.ForegroundColor = ConsoleColor.Yellow;
+            ProcessStartInfo psi = new ProcessStartInfo(config.LunarMagicPath,
+                        $"-ImportTitleMoves \"{config.TempPath}\" \"{config.TitleMovesPath}\"");
+            var p = Process.Start(psi);
+            p.WaitForExit();
+
+            if (p.ExitCode == 0)
+                Log("Title Moves Import Success!", ConsoleColor.Green);
+            else
+            {
+                Log("Title Moves Import Failure!", ConsoleColor.Red);
+                return false;
+            }
+
+            Console.WriteLine();
+
+            return true;
+        }
+
+        static public bool ImportMap16(Config config)
+        {
+            Log("Map16", ConsoleColor.Cyan);
+
+            if (string.IsNullOrWhiteSpace(config.HumanReadableMap16CLI))
+                Log("No path to human-readable-map16-cli.exe provided, using binary map16 format", ConsoleColor.Red);
+            else
+            {
+                string humanReadableDirectory;
+                if (!string.IsNullOrWhiteSpace(config.HumanReadableMap16Directory))
+                    humanReadableDirectory = config.HumanReadableMap16Directory;
+                else
+                    humanReadableDirectory = Path.Combine(Path.GetDirectoryName(config.Map16Path), Path.GetFileNameWithoutExtension(config.Map16Path));
+
+                Console.ForegroundColor = ConsoleColor.Yellow;
+                ProcessStartInfo process = new ProcessStartInfo(config.HumanReadableMap16CLI,
+                            $"--to-map16 \"{humanReadableDirectory}\" \"{config.Map16Path}\"");
+                var proc = Process.Start(process);
+                proc.WaitForExit();
+
+                if (proc.ExitCode == 0)
+                {
+                    Log("Human Readable Map16 Conversion Success!", ConsoleColor.Green);
+                }
+                else
+                {
+                    Log("Human Readable Map16 Conversion Failure!", ConsoleColor.Red);
+                    return false;
+                }
+            }
+
+            Console.ForegroundColor = ConsoleColor.Yellow;
+            ProcessStartInfo psi = new ProcessStartInfo(config.LunarMagicPath,
+                        $"-ImportAllMap16 \"{config.TempPath}\" \"{config.Map16Path}\"");
+            var p = Process.Start(psi);
+            p.WaitForExit();
+
+            if (p.ExitCode == 0)
+            {
+                Log("Map16 Import Success!", ConsoleColor.Green);
+                Console.WriteLine();
+                return true;
+            }
+            else
+            {
+                Log("Map16 Import Failure!", ConsoleColor.Red);
+                return false;
+            }
+        }
+
+        static public bool ApplyGPS(Config config)
+        {
+            Log("GPS", ConsoleColor.Cyan);
+
+            var dir = Path.GetFullPath(Path.GetDirectoryName(config.GPSPath));
+            var rom = Path.GetRelativePath(dir, Path.GetFullPath(config.TempPath));
+            Console.ForegroundColor = ConsoleColor.Yellow;
+
+            ProcessStartInfo psi = new ProcessStartInfo(config.GPSPath, $"-l \"{dir}/list.txt\" {config.GPSOptions ?? ""} \"{rom}\"");
+            psi.RedirectStandardInput = true;
+            psi.WorkingDirectory = dir;
+
+            var p = Process.Start(psi);
+            p.WaitForExit();
+
+            if (p.ExitCode == 0)
+                Log("GPS Success!", ConsoleColor.Green);
+            else
+            {
+                Log("GPS Failure!", ConsoleColor.Red);
+                return false;
+            }
+
+            Console.WriteLine();
+
+            return true;
+        }
+
+        static public bool ApplyAddmusicK(Config config)
+        {
+            Log("AddmusicK", ConsoleColor.Cyan);
+            var dir = Path.GetFullPath(Path.GetDirectoryName(config.AddMusicKPath));
+
+            // create bin folder if missing
+            {
+                string bin = Path.Combine(dir, "asm", "SNES", "bin");
+                if (!Directory.Exists(bin))
+                    Directory.CreateDirectory(bin);
+            }
+
+            var rom = Path.GetRelativePath(dir, Path.GetFullPath(config.TempPath));
+            Console.ForegroundColor = ConsoleColor.Yellow;
+
+            ProcessStartInfo psi = new ProcessStartInfo(config.AddMusicKPath, $" -noblock {config.AddmusicKOptions ?? ""} \"{rom}\"");
+            psi.RedirectStandardInput = true;
+            psi.WorkingDirectory = dir;
+
+            var p = Process.Start(psi);
+            p.WaitForExit();
+
+            if (p.ExitCode == 0)
+                Log("AddmusicK Success!", ConsoleColor.Green);
+            else
+            {
+                Log("AddmusicK Failure!", ConsoleColor.Red);
+                return false;
+            }
+
+            Console.WriteLine();
+
+            return true;
+        }
+
+        static public bool ApplyUberASM(Config config)
+        {
+            Log("UberASM", ConsoleColor.Cyan);
+            var dir = Path.GetFullPath(Path.GetDirectoryName(config.UberASMPath));
+
+            // create work folder if missing
+            {
+                string bin = Path.Combine(dir, "asm", "work");
+                if (!Directory.Exists(bin))
+                    Directory.CreateDirectory(bin);
+            }
+
+            var rom = Path.GetRelativePath(dir, Path.GetFullPath(config.TempPath));
+            Console.ForegroundColor = ConsoleColor.Yellow;
+
+            ProcessStartInfo psi = new ProcessStartInfo(config.UberASMPath, $"{config.UberASMOptions ?? "list.txt"} \"{rom}\"");
+            psi.RedirectStandardInput = true;
+            psi.RedirectStandardOutput = true;
+            psi.WorkingDirectory = dir;
+
+            StringBuilder uberasm_output = new StringBuilder();
+
+            var p = Process.Start(psi);
+            p.OutputDataReceived += (sender, args) => {
+                uberasm_output.AppendLine(args.Data);
+                Log(args.Data, ConsoleColor.Yellow);
+            };
+            p.BeginOutputReadLine();
+            p.WaitForExit();
+
+            string output = uberasm_output.ToString();
+
+            if (output.Contains(UBERASM_SUCCESS_STRING))
+                Log("UberASM Success!", ConsoleColor.Green);
+            else
+            {
+                Log("UberASM Failure!", ConsoleColor.Red);
+                return false;
+            }
+
+            Console.WriteLine();
+
+            return true;
+        }
+
+        static public bool ApplyPixi(Config config)
+        {
+            Log("PIXI", ConsoleColor.Cyan);
+
+            var dir = Path.GetFullPath(Path.GetDirectoryName(config.PixiPath));
+            Console.ForegroundColor = ConsoleColor.Yellow;
+
+            ProcessStartInfo psi = new ProcessStartInfo(config.PixiPath, $"{config.PixiOptions ?? ""} \"{config.TempPath}\"");
+            psi.RedirectStandardInput = true;
+
+            var p = Process.Start(psi);
+            p.WaitForExit();
+
+            if (p.ExitCode == 0)
+                Log("Pixi Success!", ConsoleColor.Green);
+            else
+            {
+                Log("Pixi Failure!", ConsoleColor.Red);
+                return false;
+            }
+
+            Console.WriteLine();
+            return true;
+        }
+
+        static public bool ImportGraphics(Config config)
+        {
+            Log("Graphics", ConsoleColor.Cyan);
+            {
+                Console.ForegroundColor = ConsoleColor.Yellow;
+                ProcessStartInfo psi = new ProcessStartInfo(config.LunarMagicPath,
+                            $"-ImportGFX \"{config.TempPath}\"");
+                var p = Process.Start(psi);
+                p.WaitForExit();
+
+                if (p.ExitCode == 0)
+                    Log("Import Graphics Success!", ConsoleColor.Green);
+                else
+                {
+                    Log("Import Graphics Failure!", ConsoleColor.Red);
+                    return false;
+                }
+
+                Console.WriteLine();
+                return true;
+            }
+        }
+
+        static public bool ImportSingleLevel(Config config, string level_path)
+        {
+            Console.ForegroundColor = ConsoleColor.Yellow;
+            ProcessStartInfo psi = new ProcessStartInfo(config.LunarMagicPath,
+                        $"-ImportLevel \"{config.TempPath}\" \"{level_path}\"");
+            var p = Process.Start(psi);
+            p.WaitForExit();
+
+            if (p.ExitCode != 0)
+            {
+                Log($"Level import failure on '{level_path}'!", ConsoleColor.Red);
+                return false;
+            }
+
+            return true;
+        }
+
+        static public bool ImportExGraphics(Config config)
+        {
+            Log("ExGraphics", ConsoleColor.Cyan);
+            Console.ForegroundColor = ConsoleColor.Yellow;
+            ProcessStartInfo psi = new ProcessStartInfo(config.LunarMagicPath,
+                        $"-ImportExGFX \"{config.TempPath}\"");
+            var p = Process.Start(psi);
+            p.WaitForExit();
+
+            if (p.ExitCode == 0)
+                Log("Import ExGraphics Success!", ConsoleColor.Green);
+            else
+            {
+                Log("Import ExGraphics Failure!", ConsoleColor.Red);
+                return false;
+            }
+
+            Console.WriteLine();
+            return true;
+        }
+
+        static public bool ApplyAsarPatch(Config config, string patch_path)
+        {
+            Log($"Patch '{patch_path}'", ConsoleColor.Cyan);
+
+            ProcessStartInfo psi = new ProcessStartInfo(config.AsarPath, $"{config.AsarOptions ?? ""} \"{patch_path}\" \"{config.TempPath}\"");
+
+            var p = Process.Start(psi);
+            p.WaitForExit();
+
+            if (p.ExitCode == 0)
+            {
+                Log("Patch Success!\n", ConsoleColor.Green);
+                return true;
+            }
+            else
+            {
+                Log("Patch Failure!\n", ConsoleColor.Red);
+                return false;
+            }
+        }
+
+        static public bool ImportAllLevels(Config config)
+        {
+            Log("Levels", ConsoleColor.Cyan);
+            // import levels
+            Console.ForegroundColor = ConsoleColor.Yellow;
+            ProcessStartInfo psi = new ProcessStartInfo(config.LunarMagicPath,
+                        $"-ImportMultLevels \"{config.TempPath}\" \"{config.LevelsPath}\" {config.LunarMagicLevelImportFlags ?? ""}");
+            var p = Process.Start(psi);
+            p.WaitForExit();
+
+            if (p.ExitCode == 0)
+                Log("Levels Import Success!", ConsoleColor.Green);
+            else
+            {
+                Log("Levels Import Failure!", ConsoleColor.Red);
+                return false;
+            }
+
+            Console.WriteLine();
+
+            return true;
+        }
+    }
+}

--- a/Insertables.cs
+++ b/Insertables.cs
@@ -7,32 +7,68 @@ using System.Threading.Tasks;
 
 namespace LunarHelper
 {
-    enum InsertableType
+    public enum InsertableType
     {
         Pixi,
-        Amk,
+        AddMusicK,
         Gps,
         UberAsm,
         Graphics,
+        ExGraphics,
         Map16,
         SharedPalettes,
         GlobalData,
         TitleMoves,
-        Levels,
+        SingleLevel,  // a single level
+        Levels,  // all levels
         SinglePatch,  // a single patch, specified by name
         Patches  // refers to all not otherwise specified patches
     }
 
-    class Insertable
+    public class Insertable
     {
         public readonly InsertableType type;
-        public readonly string normalized_relative_patch_path;
+        public readonly string normalized_relative_path;
 
-        public Insertable(InsertableType type, string user_specified_patch_path = null)
+        public Insertable(InsertableType type, string path = null)
         {
             this.type = type;
-            this.normalized_relative_patch_path = user_specified_patch_path.Replace('/', '\\')
-                .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar).ToLowerInvariant(); ;
+            if (path != null)
+                this.normalized_relative_path = path.Trim().Replace('/', '\\')
+                    .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar).ToLowerInvariant();
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj == null)
+            {
+                return false;
+            }
+            else
+            {
+                if (obj is Insertable)
+                {
+                    Insertable other = (Insertable)obj;
+                    if (this.type == other.type)
+                    {
+                        return (this.type != InsertableType.SinglePatch && this.type != InsertableType.SingleLevel) ||
+                            this.normalized_relative_path == other.normalized_relative_path;
+                    }
+                    else
+                    {
+                        return false;
+                    }
+                }
+                else
+                {
+                    return false;
+                }
+            }
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(type, normalized_relative_path);
         }
     }
 }

--- a/Insertables.cs
+++ b/Insertables.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace LunarHelper
+{
+    enum InsertableType
+    {
+        Pixi,
+        Amk,
+        Gps,
+        UberAsm,
+        Graphics,
+        Map16,
+        SharedPalettes,
+        GlobalData,
+        TitleMoves,
+        Levels,
+        SinglePatch,  // a single patch, specified by name
+        Patches  // refers to all not otherwise specified patches
+    }
+
+    class Insertable
+    {
+        public readonly InsertableType type;
+        public readonly string normalized_relative_patch_path;
+
+        public Insertable(InsertableType type, string user_specified_patch_path = null)
+        {
+            this.type = type;
+            this.normalized_relative_patch_path = user_specified_patch_path.Replace('/', '\\')
+                .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar).ToLowerInvariant(); ;
+        }
+    }
+}

--- a/LunarHelper.csproj
+++ b/LunarHelper.csproj
@@ -8,6 +8,12 @@
   </PropertyGroup>
 
   <PropertyGroup>
+    <AssemblyVersion>2.5.0</AssemblyVersion>
+    <FileVersion>$(AssemblyVersion)</FileVersion>
+    <Version>$(AssemblyVersion)</Version>
+  </PropertyGroup>
+
+  <PropertyGroup>
     <PathMap>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)'))=./</PathMap>
   </PropertyGroup>
 

--- a/Program.cs
+++ b/Program.cs
@@ -1430,7 +1430,7 @@ namespace LunarHelper
 
         static private bool ApplyAsarPatch(string patch_path)
         {
-            Lognl($"- Applying patch '{patch_path}'...  ", ConsoleColor.Yellow);
+            Log($"Patch '{patch_path}'", ConsoleColor.Cyan);
 
             ProcessStartInfo psi = new ProcessStartInfo(Config.AsarPath, $"{Config.AsarOptions ?? ""} \"{patch_path}\" \"{Config.TempPath}\"");
 
@@ -1439,12 +1439,12 @@ namespace LunarHelper
 
             if (p.ExitCode == 0)
             {
-                Log("Success!\n", ConsoleColor.Green);
+                Log("Patch Success!\n", ConsoleColor.Green);
                 return true;
             }
             else
             {
-                Log("Failure!\n", ConsoleColor.Red);
+                Log("Patch Failure!\n", ConsoleColor.Red);
                 return false;
             }
         }

--- a/Program.cs
+++ b/Program.cs
@@ -574,7 +574,7 @@ namespace LunarHelper
             report.global_data = Report.HashFile(Config.GlobalDataPath);
             report.title_moves = Report.HashFile(Config.TitleMovesPath);
 
-            report.build_order_hash = Report.HashList(Config.BuildOrder);
+            report.build_order_hash = Report.HashBuildOrder(Config.BuildOrder);
 
             report.lunar_helper_version = Assembly.GetExecutingAssembly().GetName().Version.ToString();
 

--- a/Program.cs
+++ b/Program.cs
@@ -10,6 +10,7 @@ using System.Text;
 using LunarHelper;
 using System.Linq;
 using System.Numerics;
+using System.Reflection;
 
 namespace LunarHelper
 {
@@ -570,6 +571,10 @@ namespace LunarHelper
             report.init_bps = Report.HashFile(Config.InitialPatch);
             report.global_data = Report.HashFile(Config.GlobalDataPath);
             report.title_moves = Report.HashFile(Config.TitleMovesPath);
+
+            report.build_order_hash = Report.HashList(Config.BuildOrder);
+
+            report.lunar_helper_version = Assembly.GetExecutingAssembly().GetName().Version.ToString();
 
             if (string.IsNullOrWhiteSpace(Config.HumanReadableMap16CLI))
             {

--- a/Program.cs
+++ b/Program.cs
@@ -364,12 +364,12 @@ namespace LunarHelper
             }
             catch (BuildPlan.MustRebuildException)
             {
-                return Build();
+                return Build(invoked_from_cli, volatile_resource_handling_preference, true);
             }
             catch (Exception e)
             {
                 Log($"Encountered exception: '{e.Message}' while planning quick build, falling back to full rebuild...", ConsoleColor.Yellow);
-                return Build();
+                return Build(invoked_from_cli, volatile_resource_handling_preference, true);
             }
             
             if (plan.Count == 0)
@@ -832,14 +832,14 @@ namespace LunarHelper
             }
         }
 
-        static private bool Build(bool invoked_from_cli = false, char volatile_resource_handling_preference = ' ')
+        static private bool Build(bool invoked_from_cli = false, char volatile_resource_handling_preference = ' ', bool skip_volatile_check = false)
         {
             if (profile_manager.current_profile != null)
                 profile_manager.WriteCurrentProfileToFile();
             else
                 profile_manager.DeleteCurrentProfileFile();
 
-            if (!HandleVolatileResources(invoked_from_cli, volatile_resource_handling_preference))
+            if (!skip_volatile_check && !HandleVolatileResources(invoked_from_cli, volatile_resource_handling_preference))
             {
                 return false;
             }

--- a/Program.cs
+++ b/Program.cs
@@ -82,7 +82,9 @@ namespace LunarHelper
             {
                 bool show_profiles = profile_manager.current_profile != null;
 
-                Log("Welcome to Lunar Helper ^_^", ConsoleColor.Cyan);
+                Lognl("Welcome to Lunar Helper v", ConsoleColor.Cyan);
+                Lognl(Assembly.GetExecutingAssembly().GetName().Version.ToString().Substring(0, 5), ConsoleColor.Cyan);
+                Log(" ^_^", ConsoleColor.Cyan);
 
                 if (show_profiles)
                 {

--- a/Report.cs
+++ b/Report.cs
@@ -35,7 +35,7 @@ namespace LunarHelper
         public string lunar_magic_level_import_flags { get; set; }
         public string asar_options { get; set; }
         public string human_readable_map16 { get; set; }
-        public int build_order_hash { get; set; }
+        public string build_order_hash { get; set; }
 
         public static string HashFile(string path)
         {
@@ -91,24 +91,18 @@ namespace LunarHelper
         }
         // SOURCE END
 
-
-        // SOURCE START
-        // Source: Stack Overflow
-        // Original question: https://stackoverflow.com/q/7278136/6875882
-        // Question asked by: Andrew Hare (https://stackoverflow.com/users/34211/andrew-hare)
-        // Code taken from answer: https://stackoverflow.com/a/30758270/6875882
-        // Author of answer: nathanchere (https://stackoverflow.com/users/243557/nathanchere)
-        public static int HashList<T>(IList<T> list)
+        public static string HashBuildOrder(List<Insertable> build_order)
         {
-            const int seed = 487;
-            const int modifier = 31;
+            MD5 md5 = MD5.Create();
 
-            unchecked
-            {
-                return list.Aggregate(seed, (current, item) =>
-                    (current * modifier) + item.GetHashCode());
-            }
+            var as_string = string.Join(' ', build_order
+                .Select(i => i.type == InsertableType.SinglePatch ? $"Patch[{i.normalized_relative_path}" :
+                i.type.ToString()));
+
+            byte[] inputBytes = Encoding.ASCII.GetBytes(as_string);
+            byte[] hashBytes = md5.ComputeHash(inputBytes);
+
+            return Convert.ToHexString(hashBytes);
         }
-        // SOURCE END
     }
 }

--- a/Report.cs
+++ b/Report.cs
@@ -11,7 +11,9 @@ namespace LunarHelper
     class Report
     {
         [JsonIgnore]
-        public const int REPORT_FORMAT_VERSION = 2;
+        public const int REPORT_FORMAT_VERSION = 3;
+
+        public string lunar_helper_version { get; set; }
         public int report_format_version { get; set; }
         public DateTimeOffset build_time { get; set; }
         public string rom_hash { get; set; }
@@ -33,6 +35,7 @@ namespace LunarHelper
         public string lunar_magic_level_import_flags { get; set; }
         public string asar_options { get; set; }
         public string human_readable_map16 { get; set; }
+        public int build_order_hash { get; set; }
 
         public static string HashFile(string path)
         {
@@ -85,6 +88,26 @@ namespace LunarHelper
             }
 
             return BitConverter.ToString(md5.Hash).Replace("-", "").ToLower();
+        }
+        // SOURCE END
+
+
+        // SOURCE START
+        // Source: Stack Overflow
+        // Original question: https://stackoverflow.com/q/7278136/6875882
+        // Question asked by: Andrew Hare (https://stackoverflow.com/users/34211/andrew-hare)
+        // Code taken from answer: https://stackoverflow.com/a/30758270/6875882
+        // Author of answer: nathanchere (https://stackoverflow.com/users/243557/nathanchere)
+        public static int HashList<T>(IList<T> list)
+        {
+            const int seed = 487;
+            const int modifier = 31;
+
+            unchecked
+            {
+                return list.Aggregate(seed, (current, item) =>
+                    (current * modifier) + item.GetHashCode());
+            }
         }
         // SOURCE END
     }

--- a/config_project.txt
+++ b/config_project.txt
@@ -10,6 +10,7 @@
 -- if defined, the initial patch will be applied before any other steps
 -- It's good idea to open your clean ROM in Lunar Magic, save it to another location, and create a patch
 -- of that saved ROM. This lets Lunar Magic apply a VRAM patch that will be required for some things
+-- two initial patches with pretty standard setups are provided with this tool for your convenience
 initial_patch = Other/initial_patch.bps
 
 -- asar
@@ -25,6 +26,48 @@ pixi_path = Tools/pixi_v1.32/pixi.exe
 pixi_options = -l Tools/pixi_v1.32/list.txt
 addmusick_path = Tools/AddmusicK_1.0.8/AddMusicK.exe
 uberasm_path = Tools/UberASMTool14/UberASMTool.exe
+
+-- Build Order
+
+-- Specifies the order in which resources are inserted
+-- into the ROM when you use the Build function, feel free to 
+-- move items around or remove them if you're not using them
+
+-- The same step can be specified multiple times if you require things
+-- to be inserted two or more times at different points
+
+-- You can also specify individual patches in this list by just 
+-- writing out their path as it appears in the patches list above, 
+-- this patch will then be inserted at that step instead of being
+-- applied at the same time as the other Patches
+
+-- The symbols used in the list are not case-sensitive, i.e.
+-- both GPS and Gps should work and refer to the same tool
+
+build_order
+[
+	Graphics				-- Insert standard GFX
+	ExGraphics				-- Insert ExGFX
+	Map16					-- Insert Map16
+
+--  TitleMoves  			-- Uncomment this if you're inserting title moves
+
+	GlobalData				-- Insert Overworld, Title Screen and Credits 
+
+	Patches					-- Insert all remaining patches from the patches list that 
+							-- are not explicitly mentioned in this build order
+
+	PIXI					-- Insert custom sprites
+	Levels					-- Insert all levels
+
+--	PIXI					-- Uncomment this if you're using Lunar Magic 3.31 or higher
+
+	AddMusicK				-- Insert custom music
+	GPS						-- Insert custom blocks
+	UberASM					-- Insert UberASM code
+
+--  Patches/some_patch.asm  -- Example of inserting a specific patch at a different time
+]
 
 -- Optional config variables if you want to use a human readble text-based map16 format
 -- human_readable_map16_cli_path = Tools/human-readable-map16-cli.exe
@@ -52,3 +95,45 @@ global_data = Other/global_data.bps
 -- specified by test_level_dest *only* when Lunar Helper's "T - Test" option is run
 test_level = 0A7
 test_level_dest = 105
+
+-- Triggers for Quick Build (optional and advanced)
+
+-- This lets you optionally trigger additional Quick Build behavior
+
+-- In general, this should not be necessary unless you have some kind of abstract
+-- dependency between resources that requires one to be re-inserted if the 
+-- other is re-inserted
+
+-- By default, Quick Build will re-insert any resource mentioned in build_order
+-- if it detects a change in it (i.e. if a sprite's code is changed or PIXI's list
+-- file is updated, Quick Build will re-insert PIXI)
+
+-- This list lets you add onto that behavior, an entry in this list takes the form
+-- "X -> Y", meaning "if resource X is re-inserted, also re-insert resource Y afterwards",
+-- for example, "PIXI -> GPS" would cause GPS to be re-inserted by Quick Build whenever
+-- it re-inserts PIXI
+
+-- Note that these triggers cascade, i.e. if we also have the trigger "GPS -> Map16", 
+-- when PIXI is re-inserted, GPS will be re-inserted at some point afterwards and then
+-- Map16 will be re-inserted at some pointer after that, even if no change in GPS was detected
+
+-- You can use any symbol mentioned in the build_order in to specify a trigger, with the 
+-- exception of the "Patches" symbol (individual patches are fine!)
+
+-- Any re-insertions that are not the cause or effect of a trigger will be handled after 
+-- all triggers/triggered insertions have taken place
+
+quick_build_triggers
+[
+-- 	Examples of triggers
+
+-- 	PIXI -> GPS  							-- Re-insert GPS after PIXI is re-inserted
+
+-- 	GPS -> Map16							-- Re-insert Map16 after GPS is re-inserted, 
+											-- combined with the first trigger, this means that if 
+											-- PIXI is re-inserted, GPS will be re-inserted at some
+											-- point afterwards and then Map16 will be re-inserted
+											-- at some point after that
+
+--  Patches/some_patch.asm -> UberASM		-- Re-insert UberASM whenever some_patch.asm is re-inserted
+]

--- a/config_project.txt
+++ b/config_project.txt
@@ -1,11 +1,11 @@
 -- this is an example project file
+-- (Note: anything on a line after -- is a comment and is ignored by Lunar Helper!)
 -- Lunar Helper will load every config_*.txt file in its directory.
 -- For a solo project, you could simply configure everything in one big config file,
 -- but for collabs it's a good idea to split config files between things that 
 -- are relative to the project path like levels, and tools like Lunar Magic that each
 -- collaborator may have installed at a different location, as in this example
 -- (see config_user.txt for the rest of the example configuration)
- 
  
 -- if defined, the initial patch will be applied before any other steps
 -- It's good idea to open your clean ROM in Lunar Magic, save it to another location, and create a patch
@@ -21,11 +21,29 @@ patches
 ]
 
 -- tools
+asar_path = ../Tools/asar181/asar.exe
+lm_path = ../Tools/Lunar Magic 3.2.1/Lunar Magic.exe
+flips_path = ../Tools/FLIPS/flips.exe
 gps_path = Tools/GPS (V1.4.21)/gps.exe
 pixi_path = Tools/pixi_v1.32/pixi.exe
 pixi_options = -l Tools/pixi_v1.32/list.txt
 addmusick_path = Tools/AddmusicK_1.0.8/AddMusicK.exe
 uberasm_path = Tools/UberASMTool14/UberASMTool.exe
+
+-- uncomment this if you're using the human readable map16 format
+-- human_readable_map16_cli_path = ../Tools/human-readable-map16-cli.exe
+
+-- content
+levels = Levels
+shared_palette = Other/shared.pal
+map16 = Other/all.map16
+title_moves = Other/smwtitledemo.zst
+
+-- global_data is a BPS patch file, to be created by Lunar Helper, 
+-- that will hold the overworld, ex global animations, credits, intro screen, and title moves.
+-- You will work on these things from the built output ROM in Lunar Magic, 
+-- and Lunar Monitor will automatically export them as you save your changes
+global_data = Other/global_data.bps
 
 -- Build Order
 
@@ -41,9 +59,6 @@ uberasm_path = Tools/UberASMTool14/UberASMTool.exe
 -- this patch will then be inserted at that step instead of being
 -- applied at the same time as the other Patches
 
--- The symbols used in the list are not case-sensitive, i.e.
--- both GPS and Gps should work and refer to the same tool
-
 build_order
 [
     Graphics                -- Insert standard GFX
@@ -52,6 +67,7 @@ build_order
 
 --  TitleMoves              -- Uncomment this if you're inserting title moves
 
+    SharedPalettes          -- Insert Shared Palettes 
     GlobalData              -- Insert Overworld, Title Screen and Credits 
 
     Patches                 -- Insert all remaining patches from the patches list that 
@@ -79,61 +95,7 @@ build_order
 -- uberasm_options = my_list.txt
 -- lm_level_import_flags = 0
 
--- content
-levels = Levels
-shared_palette = Other/shared.pal
-map16 = Other/all.map16
-title_moves = Other/smwtitledemo.zst
-
--- global_data is a BPS patch file, to be created by Lunar Helper, 
--- that will hold the overworld, ex global animations, credits, intro screen, and title moves.
--- You will work on these things from the built output ROM in Lunar Magic, 
--- and Lunar Monitor will automatically export them as you save your changes
-global_data = Other/global_data.bps
-
 -- test_level is a 3-digit hex value specifying the level number of a level that will be copied to the 3-digit level number
 -- specified by test_level_dest *only* when Lunar Helper's "T - Test" option is run
 test_level = 0A7
 test_level_dest = 105
-
--- Triggers for Quick Build (optional and advanced)
-
--- This lets you optionally trigger additional Quick Build behavior
-
--- In general, this should not be necessary unless you have some kind of abstract
--- dependency between resources that requires one to be re-inserted if the 
--- other is re-inserted
-
--- By default, Quick Build will re-insert any resource mentioned in build_order
--- if it detects a change in it (i.e. if a sprite's code is changed or PIXI's list
--- file is updated, Quick Build will re-insert PIXI)
-
--- This list lets you add onto that behavior, an entry in this list takes the form
--- "X -> Y", meaning "if resource X is re-inserted, also re-insert resource Y afterwards",
--- for example, "PIXI -> GPS" would cause GPS to be re-inserted by Quick Build whenever
--- it re-inserts PIXI
-
--- Note that these triggers cascade, i.e. if we also have the trigger "GPS -> Map16", 
--- when PIXI is re-inserted, GPS will be re-inserted at some point afterwards and then
--- Map16 will be re-inserted at some pointer after that, even if no change in GPS was detected
-
--- You can use any symbol mentioned in the build_order in to specify a trigger, with the 
--- exception of the "Patches" symbol (individual patches are fine!)
-
--- Any re-insertions that are not the cause or effect of a trigger will be handled after 
--- all triggers/triggered insertions have taken place
-
-quick_build_triggers
-[
---  Examples of triggers
-
---  PIXI -> Gps                         -- Re-insert GPS after PIXI is re-inserted
-
---  GPS -> Map16                        -- Re-insert Map16 after GPS is re-inserted, 
-                                        -- combined with the first trigger, this means that if 
-                                        -- PIXI is re-inserted, GPS will be re-inserted at some
-                                        -- point afterwards and then Map16 will be re-inserted
-                                        -- at some point after that
-
---  Patches/some_patch.asm -> UberASM   -- Re-insert UberASM whenever some_patch.asm is re-inserted
-]

--- a/config_project.txt
+++ b/config_project.txt
@@ -16,8 +16,8 @@ initial_patch = Other/initial_patch.bps
 -- asar
 patches
 [
-	Patches\retry\retry.asm
-	Patches\asarspritetiles.asm
+    Patches\retry\retry.asm
+    Patches\asarspritetiles.asm
 ]
 
 -- tools
@@ -46,25 +46,25 @@ uberasm_path = Tools/UberASMTool14/UberASMTool.exe
 
 build_order
 [
-	Graphics				-- Insert standard GFX
-	ExGraphics				-- Insert ExGFX
-	Map16					-- Insert Map16
+    Graphics                -- Insert standard GFX
+    ExGraphics              -- Insert ExGFX
+    Map16                   -- Insert Map16
 
---  TitleMoves  			-- Uncomment this if you're inserting title moves
+--  TitleMoves              -- Uncomment this if you're inserting title moves
 
-	GlobalData				-- Insert Overworld, Title Screen and Credits 
+    GlobalData              -- Insert Overworld, Title Screen and Credits 
 
-	Patches					-- Insert all remaining patches from the patches list that 
-							-- are not explicitly mentioned in this build order
+    Patches                 -- Insert all remaining patches from the patches list that 
+                            -- are not explicitly mentioned in this build order
 
-	PIXI					-- Insert custom sprites
-	Levels					-- Insert all levels
+    PIXI                    -- Insert custom sprites
+    Levels                  -- Insert all levels
 
---	PIXI					-- Uncomment this if you're using Lunar Magic 3.31 or higher
+--  PIXI                    -- Uncomment this if you're using Lunar Magic 3.31 or higher
 
-	AddMusicK				-- Insert custom music
-	GPS						-- Insert custom blocks
-	UberASM					-- Insert UberASM code
+    AddMusicK               -- Insert custom music
+    GPS                     -- Insert custom blocks
+    UberASM                 -- Insert UberASM code
 
 --  Patches/some_patch.asm  -- Example of inserting a specific patch at a different time
 ]
@@ -125,15 +125,15 @@ test_level_dest = 105
 
 quick_build_triggers
 [
--- 	Examples of triggers
+--  Examples of triggers
 
--- 	PIXI -> GPS  							-- Re-insert GPS after PIXI is re-inserted
+--  PIXI -> Gps                         -- Re-insert GPS after PIXI is re-inserted
 
--- 	GPS -> Map16							-- Re-insert Map16 after GPS is re-inserted, 
-											-- combined with the first trigger, this means that if 
-											-- PIXI is re-inserted, GPS will be re-inserted at some
-											-- point afterwards and then Map16 will be re-inserted
-											-- at some point after that
+--  GPS -> Map16                        -- Re-insert Map16 after GPS is re-inserted, 
+                                        -- combined with the first trigger, this means that if 
+                                        -- PIXI is re-inserted, GPS will be re-inserted at some
+                                        -- point afterwards and then Map16 will be re-inserted
+                                        -- at some point after that
 
---  Patches/some_patch.asm -> UberASM		-- Re-insert UberASM whenever some_patch.asm is re-inserted
+--  Patches/some_patch.asm -> UberASM   -- Re-insert UberASM whenever some_patch.asm is re-inserted
 ]

--- a/config_user.txt
+++ b/config_user.txt
@@ -7,11 +7,6 @@ output = my_hack.smc
 temp = temp.smc
 package = my_hack.bps
 
--- tools
-asar_path = ../Tools/asar181/asar.exe
-lm_path = ../Tools/Lunar Magic 3.2.1/Lunar Magic.exe
-flips_path = ../Tools/FLIPS/flips.exe
-
 -- emulator settings
 -- you can set emulator_path to an emulator of your choosing that will be used
 -- to run your ROM if you use the Test or Run functions from Lunar Helper's menu

--- a/readmes/single.txt
+++ b/readmes/single.txt
@@ -735,9 +735,8 @@ ignore them using this config variable like this
 
 ### Finishing up ###
 
-Before trying to use Lunar Helper, please get the included Lunar Monitor set 
-up and then return to the readme in the root directory of this zip archive to 
-learn what you should do once both of these tools are set up!
+After configuring the tool, you should be able to use it easily by launching it and using the 
+included menu.
 
 Some advanced features of Lunar Helper are listed below, if you're just starting out, you might 
 prefer to get familiar with Lunar Helper first before diving into these!


### PR DESCRIPTION
Headlines:
- Allows customizing build order
- Allows triggering additional re-insertions when Quick Build finds a change in a tool/resource
- Fixes ROM checksum being invalidated by Build
- Adds support for comments anywhere inside config files
- Adds a retry prompt when renaming temp files to the final output files fails